### PR TITLE
Feature/inflections workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ PRONUNCIATIONS ?= TRUE
 # If true adds additional information to entries. The combined dictionary ignores this flag due to size constraints
 ADDITIONAL_INFO ?= TRUE
 
+# If true, inflections will be indexed as readings instead of adding then as inflection rules. 
+# This is a workaround for inflected forms to be found in the Android or iOS Kindle Apps, since they do not support inflection rules.
+# It should be false when building for Kindle devices, since inflections are supposed to work fine in this devices.
+INFLECTIONS_AS_READINGS ?= FALSE
+
 ISWSL ?= FALSE
 
 ifeq ($(PRONUNCIATIONS), TRUE)
@@ -29,6 +34,10 @@ endif
 
 ifeq ($(ADDITIONAL_INFO), TRUE)
 	FLAGS += -i
+endif
+
+ifeq ($(INFLECTIONS_AS_READINGS), TRUE)
+	FLAGS += -f
 endif
 
 ifeq ($(OS), Windows_NT)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Download
 You can download the latest version of the dictionary from
 [here](https://github.com/jrfonseca/jmdict-kindle/releases).
 
+Workaround version for apps or devices not supporting inflections (i.e. Android app): [workaround](https://github.com/xelloss1012/jmdict-kindle/releases/tag/3.0.20220129-workaround)
 
 Install
 =======

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ well with other _e-ink_ Kindle devices
 
 The dictionary will *not* work well on _Kindle Fire_ or _Kindle Android App_,
 or any Android based Kindle, because the Kindle software on those platforms
-does not support inflection lookups. **Note:** As a workaround, we have added a parameter that allows to build an special version of the dictionary whith the inflected forms indexed as alternate readings, they will not work fully as inflections,
+does not support inflection lookups. **Note:** As a workaround, we have added a parameter that allows to build an special version of the dictionary with the inflected forms indexed as alternate readings, they will not work fully as inflections,
 but at least they will be found and the main word should be shown.
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ well with other _e-ink_ Kindle devices
 
 The dictionary will *not* work well on _Kindle Fire_ or _Kindle Android App_,
 or any Android based Kindle, because the Kindle software on those platforms
-does not support inflection lookups.
+does not support inflection lookups. **Note:** As a workaround, we have added a parameter that allows to build an special version of the dictionary whith the inflected forms indexed as alternate readings, they will not work fully as inflections,
+but at least they will be found and the main word should be shown.
 
 
 Download
@@ -70,7 +71,7 @@ To install any of the dictionaries (you can also install all three of them) into
 Kindle Android App
 ------------------
 
-**NOTE: Unfortunately the Kindle Android App does not support dictionary inflections, yielding verbs lookup practically impossible. No known workaround.**
+**NOTE: Unfortunately the Kindle Android App does not support dictionary inflections, yielding verbs lookup practically impossible.** As a workaround, we have added a parameter that allows to build an special version of the dictionary whith the inflected forms indexed as alternate readings, they will not work fully as inflections, but at least they will be found and the main word should be shown.
 
 * rename `jmdict.mobi` or any of the other two dictionaries as `B005FNK020_EBOK.prc`
 
@@ -151,6 +152,11 @@ PRONUNCIATIONS ?= TRUE
 
 # If true adds additional information to entries. The combined dictionary ignores this flag due to size constraints
 ADDITIONAL_INFO ?= TRUE
+
+# If true, inflections will be indexed as readings instead of adding then as inflection rules. 
+# This is a workaround for inflected forms to be found in the Android or iOS Kindle Apps, since they do not support inflection rules.
+# It should be false when building for Kindle devices, since inflections are supposed to work fine in this devices.
+INFLECTIONS_AS_READINGS ?= FALSE
 ```
 
 Build with make to create all 3 dictionaries (_Note the combined dictionary will not build with Kindle Previewer due to size constraints_):

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Download
 You can download the latest version of the dictionary from
 [here](https://github.com/jrfonseca/jmdict-kindle/releases).
 
-Workaround version for apps or devices not supporting inflections (i.e. Android app): [workaround](https://github.com/xelloss1012/jmdict-kindle/releases/tag/3.0.20220129-workaround)
+Workaround version for apps or devices not supporting inflections (i.e. Android app): [workaround](https://github.com/xelloss1012/jmdict-kindle/releases/)
 
 Install
 =======

--- a/jmdict.py
+++ b/jmdict.py
@@ -270,7 +270,7 @@ class JMdictParser(XmlParser):
         orthos_with_inflections = []
         for ortho in orthos:
             # Add current ortho
-            orthos_with_inflections.append(orthos_with_inflections)
+            orthos_with_inflections.append(ortho)
             # Don't try to inflect katakana words
             if not is_katakana(ortho.value):
                 for pos in posses:

--- a/jmdict.py
+++ b/jmdict.py
@@ -225,6 +225,7 @@ class JMdictParser(XmlParser):
 
     def __init__(self, filename):
         XmlParser.__init__(self, gzip.open(filename, "rb"))
+        self.inflections_as_readings = False
 
     def parse(self):
         entries = []
@@ -266,7 +267,10 @@ class JMdictParser(XmlParser):
             for pos in sense.pos:
                 posses.add(pos)
 
+        orthos_with_inflections = []
         for ortho in orthos:
+            # Add current ortho
+            orthos_with_inflections.append(orthos_with_inflections)
             # Don't try to inflect katakana words
             if not is_katakana(ortho.value):
                 for pos in posses:
@@ -276,7 +280,16 @@ class JMdictParser(XmlParser):
                         sys.stderr.write(f"error: {ex.args[0]}\n")
                     else:
                         if infl_dict:
-                            ortho.inflgrps[pos] = list(infl_dict.values())
+                            # If the flag inflections_as_readings is True, we add each inflection as a new Ortho. 
+                            # This way they will be indexed as alternate readings and so they will be found in devices that do not support inflections.
+                            # otherwise, we assign the inflections to the current ortho
+                            if self.inflections_as_readings:
+                                for infl in infl_dict.values():
+                                    orthos_with_inflections.append(Ortho(infl, ortho.rank, {}))                                               
+                            else:
+                                ortho.inflgrps[pos] = list(infl_dict.values())                 
+        # Reassing
+        orthos = orthos_with_inflections
 
         entry = Entry(senses, orthos, kanjis, readings)
 
@@ -488,6 +501,14 @@ def get_args():
         default=False,
         help="If this flag is set additional entry information wil be added to the dictionaries specified with -d.",
     )
+    arg_parser.add_argument(
+        "-f",
+        "--inflections_as_readings",
+        action="store_true",
+        default=False,
+        help="If this flag is set, inflections will be added as readings instead of inflection rules. This is a workaround for Android and iOS Kindle apps",
+    )
+
     return arg_parser.parse_args()
 
 
@@ -498,6 +519,9 @@ def main():
     if args.dictionary.create_jmdict or args.dictionary.create_combined:
         sys.stderr.write("Parsing JMdict_e.gz...\n")
         parser = JMdictParser("JMdict_e.gz")
+        if args.inflections_as_readings:
+            sys.stderr.write("Inflections will be added as readings (Android and iOS Kindle apps workaround)...\n")
+            parser.inflections_as_readings = args.inflections_as_readings
         jmdict_entries = parser.parse()
         if args.pronunciation:
             sys.stderr.write("Adding pronunciations...\n")


### PR DESCRIPTION
Add new config parameter INFLECTIONS_AS_READINGS to the makefile that will allow to build a dictionary version with the inflections indexed as readings. 

**Note:** This is intended as a workaround for Kindle devices or apps that do not support inflections (#15)